### PR TITLE
feat(templates): add k8s templates for basic cronjob

### DIFF
--- a/pages/api/_assets/cronjob_template.yaml
+++ b/pages/api/_assets/cronjob_template.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ CRONJOB_NAME }}
+  namespace: cronjobs
+
+spec:
+  schedule: "{{ CRONJOB_SCHEDULE }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cronk8s
+            image: busybox:latest
+            command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            env:
+              - name: POCKETBASE_ADMIN_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    key: username
+                    name: pocketbase-admin
+              - name: POCKETBASE_ADMIN_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    key: password
+                    name: pocketbase-admin
+          restartPolicy: OnFailure

--- a/pages/api/_assets/pocketbase_secrets.yaml
+++ b/pages/api/_assets/pocketbase_secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pocketbase-admin
+  namespace: cronjobs
+type: Opaque
+data:
+  username: {{ BASE64_ADMIN_USERNAME }}
+  password: {{ BASE64_ADMIN_PASSWORD }}


### PR DESCRIPTION
Add K8s templates to run the cronjobs with it secrets. For now using busybox as a proof of concept

# QA

- `snap install microk8s`
-  `microk8s.kubectl create namespace cronjobs`
- Replace the variables between `{{  }}` with cool values
- `microk8s.kubectl apply -f pages/api/_assets/pocketbase_secrets.yaml`
- `microk8s.kubectl apply -f pages/api/_assets/cronjob_template.yaml`
- `microk8s.kubectl get pods -n cronjobs`
- You should see some cronjobs starting 